### PR TITLE
修复最新版本twig_template_get_attributes问题

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "twig/twig": "^3.1.1",
+        "twig/twig": "~3.0 <=3.8.0",
         "topthink/framework": "^6.0 || ^8.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
修复twig更新后出现 `Call to undefined function twig_template_get_attributes()` 的问题